### PR TITLE
add pypi badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 [![CI Status](
 https://github.com/IBM/tnz/workflows/CI/badge.svg
 )](https://github.com/IBM/tnz/actions/workflows/pipeline.yml)
+[![PyPi Status](
+https://img.shields.io/pypi/v/tnz.svg
+)](https://pypi.org/project/tnz)
 
 # tnz
 


### PR DESCRIPTION
A pypi badge makes it obvious that pypi is in use and gives a easy way to see the latest version there.

Signed-off-by: Neil Johnson <najohnsn@us.ibm.com>