### PR TITLE
cmdqueue appended while in alt screen

### DIFF
--- a/tnz/zti.py
+++ b/tnz/zti.py
@@ -2134,6 +2134,10 @@ HELP and HELP KEYS commands for more information.
 
         try:
             while True:
+                if self.cmdqueue:  # plugin added cmd to process?
+                    self.shell_mode()
+                    return 1  # timeout?
+
                 cstr = self.__tty_read(win, 0, refresh=refresh)
                 refresh = None
                 if (cstr == "" and  # session change
@@ -2184,6 +2188,10 @@ HELP and HELP KEYS commands for more information.
                             _logger.debug("before win.move")
                             win.move(ypos+currow-1, xpos+curcol-1)
                             _logger.debug("after win.move")
+
+                    if self.cmdqueue:  # plugin added cmd to process?
+                        self.shell_mode()
+                        return 1  # timeout?
 
                     cstr = self.__tty_read(win, tout)
                     if waitc in (_WAIT_KEYLOCK, _WAIT_SCREEN):


### PR DESCRIPTION
This PR allows another thread (maybe a thread created by a plugin) to append to the zti cmdqueue while in _full/alternate screen_ mode. When the additional command is recognized, zti will return to the command line (_normal screen_) mode to process the command. Presumably the thread that appended to the cmdqueue uses `tnz.wakeup_wait()` to get the command(s) processed in a timely manner.