### PR TITLE
let tnz/socket resolve full hostname

### DIFF
--- a/tnz/zti.py
+++ b/tnz/zti.py
@@ -55,7 +55,6 @@ import logging
 import os
 import platform
 import signal
-import socket
 import sys
 import tempfile
 import threading
@@ -511,12 +510,6 @@ class Zti(cmd.Cmd):
                 sesname = parts[0]
                 port = parts[1]
 
-            if "." not in hostname:
-                fqdn = socket.getfqdn()
-                fqdn = fqdn.split(".")
-                if len(fqdn) > 1:
-                    hostname += "."+".".join(fqdn[1:])
-
             if "." in hostname:
                 parts = hostname.split(".", 1)
                 sesname = parts[0]
@@ -592,12 +585,6 @@ class Zti(cmd.Cmd):
                 parts = hostname.split(":", 1)
                 hostname = parts[0]
                 port = parts[1]
-
-            if "." not in hostname:
-                fqdn = socket.getfqdn()
-                fqdn = fqdn.split(".")
-                if len(fqdn) > 1:
-                    hostname += "."+".".join(fqdn[1:])
 
             if port is not None:
                 oldport = ati.ati["SESSION_PORT"]

--- a/tnz/zti.py
+++ b/tnz/zti.py
@@ -891,7 +891,7 @@ class Zti(cmd.Cmd):
         print(f" SESSION_DEVICE_TYPE={tns.terminal_type}")
 
         if tns.alt:
-            print(" Alternate code page IBM-"+str(tns.cp_01))
+            print(" Alternate code page IBM-"+str(tns.cp_F1))
         else:
             print(" Alternate code page not supported")
 


### PR DESCRIPTION
This PR resolves #35 

Also fixes a recent problem where `cp_01` was changed to `cp_F1` - except for a reference in `zti.py`.