### PR TITLE
AtiError and DittoError

### DIFF
--- a/test/test_ati.py
+++ b/test/test_ati.py
@@ -1,5 +1,6 @@
 from tnz.ati import *
 from tnz.ati import Ati
+from tnz.ati import AtiError
 
 
 def test_num():
@@ -55,22 +56,23 @@ def test_maxlostwarn():
     with Ati():
         set("MAXLOSTWARN", 1)
         set("SESSION_PORT", 9)  # no tcp? or discard?
+        got_expected_error = False
         try:
             set("SESSION", "BADSES")
 
-        except Exception:
-            pass
+        except AtiError:
+            got_expected_error = True
 
-        else:
+        if not got_expected_error:
             assert value("RC") == "0"
+            got_expected_error = False
             try:
                 send(enter)
 
-            except Exception:
-                pass
+            except AtiError:
+                got_expected_error = True
 
-            else:
-                assert not "expected Exception"
+            assert got_expected_error
 
     with Ati():
         set("MAXLOSTWARN", 2)
@@ -79,11 +81,11 @@ def test_maxlostwarn():
         if value("RC") == "0":
             assert send(enter) == 12
 
+        got_expected_error = False
         try:
             send(enter)
 
-        except Exception:
-            pass
+        except AtiError:
+            got_expected_error = True
 
-        else:
-            assert not "expected Exception"
+        assert got_expected_error

--- a/tnz/ati.py
+++ b/tnz/ati.py
@@ -757,7 +757,7 @@ class Ati():
             return  # TODO rc=4
 
         if unam in self.__session_tnz:
-            raise RuntimeError(unam+" already established")
+            raise AtiError(unam+" already established")
 
         tns = self.__session_tnz[session]
         self.__session_tnz[unam] = tns
@@ -784,7 +784,7 @@ class Ati():
             logger.critical(value)
 
     def scrcomp(self, value):
-        raise RuntimeError("not implemented")
+        raise AtiError("not implemented")
 
     def scrhas(self, *args, wc=None):
         """Check current screen for a string.
@@ -1632,7 +1632,7 @@ class Ati():
             valstr = str(value)
 
         if verifycert is not None and unam != "SESSION":
-            raise RuntimeError("Using verifycert requires SESSION")
+            raise AtiError("Using verifycert requires SESSION")
 
         if unam == "SESSION":
             self.__set_session(value,
@@ -1693,7 +1693,7 @@ class Ati():
             self.__logresult("%s = %r", unam, str(self.__gv[unam]))
 
         elif unam == "SCRUPDATE":
-            raise RuntimeError('not implemented')
+            raise AtiError('not implemented')
 
         elif unam == "KEYUNLOCK":
             self.keyunlock = value
@@ -1720,7 +1720,7 @@ class Ati():
             self.__logresult("%s = %r", unam, valstr)
 
         elif unam == "SCRLIBS":
-            raise RuntimeError('not implemented')
+            raise AtiError('not implemented')
 
         elif xtern and unam in ("SESSIONS",
                                 "MAXCOL",
@@ -1736,7 +1736,7 @@ class Ati():
                                 "DATETIME",
                                 "SENDSTR",
                                 "SESLOST"):
-            raise RuntimeError(unam+" is read-only")
+            raise AtiError(unam+" is read-only")
 
         elif unam == "SESLOST":
             self.__drop_session()
@@ -1776,7 +1776,7 @@ class Ati():
 
             if value is not None:
                 if unam in self.__gv:
-                    raise RuntimeError(unam+" already set")
+                    raise AtiError(unam+" already set")
 
                 self.__gv[unam] = value
 
@@ -1985,7 +1985,7 @@ class Ati():
                         self.__shell_mode()
 
                     if raise_it:
-                        raise RuntimeError("WAIT TIMEOUT occurred")
+                        raise AtiError("WAIT TIMEOUT occurred")
 
                 self.set("RC", ati_rc, xtern=False)
                 return ati_rc
@@ -2335,7 +2335,7 @@ class Ati():
 
         in_wait = self.__in_wait
         if in_wait and timeout != 0:
-            raise RuntimeError("Already in wait")
+            raise AtiError("Already in wait")
 
         okeylock = self.__gv["KEYLOCK"]
         if okeylock != "1":
@@ -2483,7 +2483,7 @@ class Ati():
         maxlostwarn = self.__gv["MAXLOSTWARN"]
 
         if 0 < maxlostwarn <= lostwarncnt:
-            raise RuntimeError("Excessive lost session warnings")
+            raise AtiError("Excessive lost session warnings")
 
         self.__gv["lostwarncnt"] = lostwarncnt
 
@@ -2545,7 +2545,7 @@ class Ati():
             # existing session
 
             if verifycert is not None:
-                raise RuntimeError("Used verifycert with old session")
+                raise AtiError("Used verifycert with old session")
 
             self.__gv["SESSION"] = unam
             self.__refresh()
@@ -3207,7 +3207,7 @@ class Ati():
 
     @scrlibs.setter
     def scrlibs(self, value):
-        raise RuntimeError('not implemented')
+        raise AtiError('not implemented')
 
     @property
     def scrupdate(self):
@@ -3498,6 +3498,11 @@ class _AtiConst():
 
     def __repr__(self):
         return self.name
+
+
+class AtiError(Exception):
+    """General Ati error.
+    """
 
 
 _GLOBAL = {}  # use as value in __uv to indicate to look in __gv

--- a/tnz/ditto.py
+++ b/tnz/ditto.py
@@ -135,10 +135,10 @@ class Ditto(object):
 
         ati_rc = ati.set("SESSION", session)
         if ati_rc == 1:  # reestablished session
-            raise RuntimeError("already connected")
+            raise DittoError("already connected")
 
         if ati_rc != 0:  # new session
-            raise RuntimeError(f"set session error {ati_rc}")
+            raise DittoError(f"set session error {ati_rc}")
 
     def cursor_after(self, session, identifier_string):
         """Use for Ditto @=identifier_string command text.
@@ -194,7 +194,7 @@ class Ditto(object):
 
         ati_rc = self.__ati.send(_ati.enter)
         if ati_rc != 0:
-            raise RuntimeError(f"send enter error {ati_rc}")
+            raise DittoError(f"send enter error {ati_rc}")
 
     def enter_after(self, session, identifier_string, text):
         """Shorthand for cursor_after followed by enter.
@@ -267,7 +267,7 @@ class Ditto(object):
         rval = ati.extract(length, f_or_l, matching, (row, col))
         ati_rc = _ati.num(ati.rc)
         if ati_rc != 0:
-            raise RuntimeError(f"extract error {ati_rc}")
+            raise DittoError(f"extract error {ati_rc}")
 
         return rval
 
@@ -305,14 +305,14 @@ class Ditto(object):
             ati_rc = self.__ati.send(pos, text)
 
         if ati_rc != 0:
-            raise RuntimeError(f"send error {ati_rc}")
+            raise DittoError(f"send error {ati_rc}")
 
     def set_session(self, session):
         ati = self.__ati
         if session != ati.session:
             ati_rc = ati.set("SESSION", session)
             if ati_rc != 1:  # reestablished session
-                raise RuntimeError(f"set session error {ati_rc}")
+                raise DittoError(f"set session error {ati_rc}")
 
     def verify(self, session, text, timeout=None):
         """Use for Ditto verify commands.
@@ -327,7 +327,7 @@ class Ditto(object):
             ati_rc = ati.wait(timeout, lambda: ati.scrhas(text))
 
         if ati_rc != 1:
-            raise RuntimeError(f"wait error {ati_rc}")
+            raise DittoError(f"wait error {ati_rc}")
 
     def waitfor(self, session):
         """Use for Ditto C=WAITFOR command text.
@@ -338,7 +338,7 @@ class Ditto(object):
 
         ati_rc = ati.wait(self.__active)
         if ati_rc != 1:
-            raise RuntimeError(f"wait error {ati_rc}")
+            raise DittoError(f"wait error {ati_rc}")
 
     # properties
 
@@ -402,12 +402,17 @@ class Ditto(object):
 
         ati_rc = ati.wait(self.__unlocked)  # needed?
         if ati_rc != 1:
-            raise RuntimeError(f"wait error {ati_rc}")
+            raise DittoError(f"wait error {ati_rc}")
 
         if not ati.scrhas(identifier_string):
-            raise RuntimeError("identifier string not found")
+            raise DittoError("identifier string not found")
 
         pos = (ati.numvalue("HITROW"), ati.numvalue("HITCOL"))
         ati_rc = ati.send(pos, key)
         if ati_rc != 0:
-            raise RuntimeError(f"send error {ati_rc}")
+            raise DittoError(f"send error {ati_rc}")
+
+
+class DittoError(Exception):
+    """General Ditto error.
+    """

--- a/tnz/tnz.py
+++ b/tnz/tnz.py
@@ -4816,7 +4816,7 @@ class Tnz:
                     }
 
 
-class TnzError(RuntimeError):
+class TnzError(Exception):
     """General Tnz error.
     """
 


### PR DESCRIPTION
This PR resolves #12 

A new `AtiError` class is defined. All occurrences where `ati.py` raised `RuntimeError` are changed to raise `AtiError`.
Similar changes were made to `ditto.py` with a new `DittoError`.

The MAXLOSTWARN test was updated to expect this more precise `AtiError`.

For consistency, `TnzError` was changed to inherit from `Exception` rather than `RuntimeError`.
