### PR TITLE
Python 3.6 not supported

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ '3.6', '3.7', '3.8', '3.9', '3.10' ]
+        python-version: [ '3.7', '3.8', '3.9', '3.10' ]
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
Python 3.6 is no longer supported and it seems that the ability to use github actions to test using Python 3.6 has been left to atrophy. This PR stops testing on Python 3.6. Not ready yet to claim that tnz requires >Python3.6... but I expect that day will be coming soon.