### PR TITLE
fix append for read buffer reply_mode

### DIFF
--- a/tnz/tnz.py
+++ b/tnz/tnz.py
@@ -4292,27 +4292,32 @@ class Tnz:
                     attr = self.plane_eh[addr]
                     if attr:  # if not default
                         sfe[1] += 1
-                        sfe.append(0x41, attr)
+                        sfe.append(0x41)
+                        sfe.append(attr)
 
                     attr = self.plane_fg[addr]
                     if attr:  # if not default
                         sfe[1] += 1
-                        sfe.append(0x42, attr)
+                        sfe.append(0x42)
+                        sfe.append(attr)
 
                     attr = self.plane_cs[addr]
                     if attr:  # if not default
                         sfe[1] += 1
-                        sfe.append(0x43, attr)
+                        sfe.append(0x43)
+                        sfe.append(attr)
 
                     attr = self.plane_bg[addr]
                     if attr:  # if not default
                         sfe[1] += 1
-                        sfe.append(0x45, attr)
+                        sfe.append(0x45)
+                        sfe.append(attr)
 
                     if sfe[1] != 0x40:  # if not default`
                         if fattr:
                             sfe[1] += 1
-                            sfe.append(0xc0, fattr)
+                            sfe.append(0xc0)
+                            sfe.append(fattr)
 
                         sfb = sfe
 


### PR DESCRIPTION
This PR fixes a problem with code for a Read Buffer using Extended Field or Character reply mode - code is calling append on a list and passing it 2 arguments. The intention is to append both arguments. This PR fixes the code by doing 2 separate appends - each with a single argument.

Thanks for finding/reporting @Christopher-Chappell.