### PR TITLE
fix special SESSION_PS_SIZE values

### DIFF
--- a/tnz/ati.py
+++ b/tnz/ati.py
@@ -79,7 +79,7 @@ Environment variables used:
     COLORTERM (see _termlib.py)
     DATEFORM
     ESCDELAY (see zti.py)
-    SESSION_PS_SIZE (see tnz.py)
+    SESSION_PS_SIZE
     TERM_PROGRAM (see _termlib.py)
     TNZ_COLORS (see tnz.py)
     TNZ_LOGGING (see tnz.py)
@@ -88,7 +88,7 @@ Environment variables used:
     ZTI_TITLE (see zti.py)
     _BPX_TERMPATH (see _termlib.py)
 
-Copyright 2021 IBM Inc. All Rights Reserved.
+Copyright 2021, 2023 IBM Inc. All Rights Reserved.
 
 SPDX-License-Identifier: Apache-2.0
 """
@@ -2607,7 +2607,12 @@ class Ati():
         if ps_size:
             self.__logresult("%s = %r", "SESSION_PS_SIZE", ps_size)
             try:
-                asize = _util.session_ps_size(ps_size)
+                if ps_size in ("MAX", "MAX255", "FULL", "FULL255"):
+                    from .zti import Zti
+                    asize = Zti._rows_cols(ps_size)
+                else:
+                    asize = _util.session_ps_size(ps_size)
+
                 tns.amaxrow, tns.amaxcol = asize
             except ValueError:
                 pass

--- a/tnz/tnz.py
+++ b/tnz/tnz.py
@@ -11,7 +11,7 @@ Environment variables used:
     TNZ_LOGGING
     ZTI_SECLEVEL
 
-Copyright 2021 IBM Inc. All Rights Reserved.
+Copyright 2021, 2023 IBM Inc. All Rights Reserved.
 
 SPDX-License-Identifier: Apache-2.0
 """
@@ -251,7 +251,7 @@ class Tnz:
             self.capable_color = True
 
         ps_size = os.getenv("SESSION_PS_SIZE", None)
-        if ps_size:
+        if ps_size not in (None, "MAX", "MAX255", "FULL", "FULL255"):
             try:
                 from . import _util
                 asize = _util.session_ps_size(ps_size)


### PR DESCRIPTION
This PR fixes a problem introduced by the support to copy SESSION_ environment variables into the Ati object. The problem was that only `zti.py` was able to interpret special `SESSION_PS_SIZE` values `MAX`, `MAX255`, `FULL`, and `FULL255`. Those special values were normally used as environment variables. Now that they become ati variables, ati was not able to interpret them. The ati object is updated with the ability to interpret these special values. Also, removed an annoyance that `tnz.py` does not know how to interpret the special values. In that case, they are just ignored.