### PR TITLE
fix windows paste

### DIFF
--- a/tnz/_termlib.py
+++ b/tnz/_termlib.py
@@ -328,6 +328,7 @@ class Term():
 
         if len(key) > 1:
             self.__pendinc = key[1:]
+            key = key[0]
 
         _logger.debug("getkey returning %r", key)
         return key


### PR DESCRIPTION
This PR corrects a problem introduced by #73. The problems seems to be that the changes in how keys are processed in Windows makes it much more likely that a paste action is received _in whole_ by `__getchar()`. This exposed a problem in `getkey()` where the intent was to return a single character, but instead the entire string was being returned.