### PR TITLE
bracketed paste on windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,10 +109,6 @@ select text. Once the text is selected, press Enter to copy the
 text.** There are other ways to select text, but I this to be the
 easiest.
 
-Do NOT use Control-menu->Edit->Paste to paste text (unless the
-text in the clipboard has ONLY printable characters - no line
-breaks). Instead, **use Shift+Insert to paste**.
-
 Before establishing a session, get the window sized the way you want
 it. Window resizing is not handled well in Windows. If you _do_
 resize, just use Esc to get to the command prompt then `goto` to get


### PR DESCRIPTION
This PR fixes multi-line paste on Windows.

Prior experience has been that Windows Command Prompt did not support bracketed paste. And therefore, _normal_ paste did not work well - newlines were treated as pressing _enter_ instead of newlines. To work around that, zti reacted to Shifit+Insert by grabbing text from the Windows clipboard.

Current experience is that Windows Command Prompt and Windows Terminal (on Windows 11, at least), does not give Shift+Insert to the terminal/zti. Instead, it uses Shift+Insert to paste data just like Ctrl+V. This brings back the original problem if newlines being treated as pressing _enter_.

However, in this case of Windows using Shift+Insert to paste, it seems that bracketed paste mode is supported. This PR fixes pasting in Windows by exploiting bracketed paste just like unix platforms.