### PR TITLE
pa1 for attention

### DIFF
--- a/tnz/zti.py
+++ b/tnz/zti.py
@@ -2319,8 +2319,8 @@ HELP and HELP KEYS commands for more information.
                     _logger.debug("keyed Alt+1 or Alt+Insert")
 
                     if tns.pwait or tns.system_lock_wait:
-                        curses.flash()
-                        curses.beep()
+                        # Assume Attention needed for z/VM
+                        tns.send_aid(0x6c)  # AID_PA1
                     else:
                         tns.pa1()
                         self.rewrite_keylock = True


### PR DESCRIPTION
This PR _enhances_ the PA1 key for situation in which the keyboard is locked.

Experience has show z/VM to not handle the normal ATTN (telnet BRK=243). However, it appears to expect PA1 even when the keyboard should otherwise be locked - PA1 serves as a general _attention_ key. This behavior has been observed when accessing z/OS applications _through_ z/VM.