### PR TITLE
entry_points() select or get

### DIFF
--- a/tnz/zti.py
+++ b/tnz/zti.py
@@ -1760,7 +1760,12 @@ HELP and HELP KEYS commands for more information.
             return
 
         plugins = []
-        zti_plugins = entry_points().get("zti.commands", [])
+        eps = entry_points()
+        if hasattr(eps, "select"):
+            zti_plugins = eps.select(group="zti.commands")
+        else:
+            zti_plugins = eps.get("zti.commands", [])
+
         for entry in zti_plugins:
             name = entry.name
             plugins.append(name)


### PR DESCRIPTION
This PR resolves #82. It will use the select method for the levels of Python that support/have it. Otherwise, the older/existing get method will be used.