### PR TITLE
pin dependency versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,12 @@
-black >= 23.3.0; python_version >= "3.8"
-build >= 1.0.3
-ebcdic >= 1.1.1; sys_platform != "zos"
-mkdocs-material >= 9.2.8; python_version >= "3.8"
-mkdocs-minify-plugin >= 0.7.1; python_version >= "3.8"
-mkdocstrings-python >= 1.1.2; python_version >= "3.8"
-pycodestyle >= 2.10.0
-pylint >= 2.17.5
-pytest >= 7.4.2
-twine >= 4.0.2; sys_platform != "zos"
-wheel >= 0.41.2
+black==24.4.2; python_version>="3.8"
+build==1.0.3
+ebcdic==1.1.1; sys_platform!="zos"
+mkdocs-material==9.2.8; python_version>="3.8"
+mkdocs-minify-plugin==0.8.0; python_version>="3.8"
+mkdocstrings-python==1.10.5; python_version>="3.8"
+pycodestyle==2.10.0
+pylint==2.17.5
+pytest==8.2.2; python_version>="3.8"
+pytest>=7.4.2; python_version<"3.8"
+twine==5.1.1; sys_platform!="zos" and python_version>="3.8"
+wheel==0.41.2


### PR DESCRIPTION
This PR pins dependency versions to enable more value out of dependabot.

This PR follows the strategy taken by #79. There are some dependencies whose latest version is not available for the lower versions of Python. Environmental markers were added on such dependencies when they are only needed for building the package or documentation. Multiple pytest specifiers are provided to use the latest version when possible and still test on lower Python versions.

Note that spaces are removed around operators because I've seen versions of dependabot remove spaces on the right side of operators.