### PR TITLE
dev only with latest Python version

### DIFF
--- a/.github/workflows/mkdocs-build.yml
+++ b/.github/workflows/mkdocs-build.yml
@@ -3,13 +3,18 @@ on:
   push:
     branches:
       - main
+
 jobs:
-  deploy:
+  deploy-gh-pages:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: 3.x
-      - run: pip install --disable-pip-version-check -r requirements.txt
-      - run: mkdocs gh-deploy --force
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+
+    - uses: actions/setup-python@v5
+      with:
+        python-version: 3.12
+
+    - run: pip install --disable-pip-version-check -r requirements.txt
+    - run: mkdocs gh-deploy --force

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -3,11 +3,32 @@ name: CI/CD
 on: push
 
 jobs:
-  CI:
+  build-wheel:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+
+    - uses: actions/setup-python@v5
+      with:
+        python-version: 3.12
+
+    - run: pip install --disable-pip-version-check -r requirements.txt
+    - run: pycodestyle tnz/*.py
+    - run: python -m build --wheel --outdir dist/
+    - uses: actions/upload-artifact@v4
+      with:
+        name: dist
+        path: dist/
+
+  test-wheel:
+    needs: build-wheel
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ '3.7', '3.8', '3.9', '3.10' ]
+        python-version: [ '3.7', '3.8', '3.9', '3.10', '3.11', '3.12' ]
 
     steps:
     - uses: actions/checkout@v4
@@ -16,41 +37,28 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
 
-    - name: Install dependencies
-      run: |
-        pip install --disable-pip-version-check -r requirements.txt
+    - run: pip install --disable-pip-version-check pytest -c requirements.txt
+    - uses: actions/download-artifact@v4
+    - run: pip install $(ls dist/*.whl)
+    - run: zti --version
+    - run: pytest
 
-    - name: Lint
-      run: |
-        pycodestyle tnz/*.py
-
-    - name: Install tnz
-      run: |
-        pip install .
-
-    - name: Run tests
-      run: |
-        pytest
-
-  CD:
+  deploy-pypi:
     if: startsWith(github.ref, 'refs/tags')
-    needs: CI
+    needs: build-wheel
     runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v4
+      with:
+        fetch-tags: true
+
     - uses: actions/setup-python@v5
+      with:
+        python-version: 3.12
 
-    - name: Install dependencies
-      run: |
-        pip install --disable-pip-version-check -r requirements.txt
-
-    - name: Build dist
-      run: |
-        python -m build --wheel --outdir dist/
-
-    - name: Publish 
+    - run: pip install --disable-pip-version-check -r requirements.txt
+    - uses: actions/download-artifact@v4
+    - run: twine upload --non-interactive -u __token__ dist/*
       env:
         TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
-      run: |
-        twine upload --non-interactive -u __token__ dist/*

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,13 +1,12 @@
-black==24.4.2; python_version>="3.8"
+black==24.4.2
 build==1.0.3
 ebcdic==1.1.1; sys_platform!="zos"
-mkdocs-material==9.5.31; python_version>="3.8"
-mkdocs-minify-plugin==0.8.0; python_version>="3.8"
-mkdocstrings-python==1.10.5; python_version>="3.8"
-pycodestyle==2.10.0; python_version<"3.8"
-pycodestyle==2.12.0; python_version>="3.8"
+mkdocs-material==9.5.31
+mkdocs-minify-plugin==0.8.0
+mkdocstrings-python==1.10.5
+pycodestyle==2.12.0
 pylint==2.17.5
 pytest==8.3.2; python_version>="3.8"
 pytest>=7.4.2; python_version<"3.8"
-twine==5.1.1; sys_platform!="zos" and python_version>="3.8"
+twine==5.1.1; sys_platform!="zos"
 wheel==0.41.2


### PR DESCRIPTION
This PR detaches much of the CI/CD from old Python versions. To do this, the _development_ actions such as building and linting are only done with the _latest_ Python version. Only the `pytest` action is done with all supported versions. This is being done because there seem to be just too many dependencies that cannot be satisfied by old Python versions.

This PR also adds testing on Python 3.11 and 3.12.