### PR TITLE
Revert "Bump mkdocs-material from 9.5.31 to 9.5.32"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 black==24.8.0
 build==1.2.1
 ebcdic==1.1.1; sys_platform!="zos"
-mkdocs-material==9.5.32
+mkdocs-material==9.5.31
 mkdocs-minify-plugin==0.8.0
 mkdocstrings-python==1.10.7
 pycodestyle==2.12.1


### PR DESCRIPTION
Reverts IBM/tnz#119

Caused a build error: https://github.com/IBM/tnz/actions/runs/10456853320/job/28955152960

Need to investigate more why the breakage occurred:
> ```
> File "/opt/hostedtoolcache/Python/3.12.4/x64/lib/python3.12/site-packages/mkdocstrings_handlers/python/handler.py", line 15, in <module>
>     from griffe import (
> ImportError: cannot import name 'patch_logger' from 'griffe' (/opt/hostedtoolcache/Python/3.12.4/x64/lib/python3.12/site-packages/griffe/__init__.py). Did you mean: 'patch_loggers'?
> Error: Process completed with exit code 1.
> ```


