### PR TITLE
pin griffe

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 black==24.8.0
 build==1.2.1
 ebcdic==1.1.1; sys_platform!="zos"
+griffe==0.49.0
 mkdocs-material==9.5.31
 mkdocs-minify-plugin==0.8.0
 mkdocstrings-python==1.10.7


### PR DESCRIPTION
Uplevel griffe is causing problems with mkdocs. This PR pins it at a version that works.