### PR TITLE
test mkdocs build

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -23,6 +23,8 @@ jobs:
         name: dist
         path: dist/
 
+    - run: mkdocs build
+
   test-wheel:
     needs: build-wheel
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR adds a `mkdocs build` step to help validate that the `mkdocs gh-deploy` will work when PRs are merged.