### PR TITLE
SESSION_SSL_MINIMUM_TLS

### DIFF
--- a/tnz/tnz.py
+++ b/tnz/tnz.py
@@ -3747,6 +3747,10 @@ class Tnz:
         else:
             context.verify_mode = ssl.CERT_NONE
 
+        minimum_version = getenv("SESSION_SSL_MINIMUM_TLS")
+        if minimum_version == "1.1":
+            context.minimum_version = ssl.TLSVersion.TLSv1_1
+
         return context
 
     def __erase(self, saddr, eaddr):


### PR DESCRIPTION
This PR is intended to help with #93. It allows for the setting of environment variable `SESSION_SSL_MINIMUM_TLS=1.1` to trigger tnz to _downgrade_ the minimum allowed version of TLS to 1.1. In my experience, the minimum allowed has been 1.2.