### PR TITLE
room for session selector

### DIFF
--- a/tnz/zti.py
+++ b/tnz/zti.py
@@ -3451,13 +3451,13 @@ HELP and HELP KEYS commands for more information.
         if session_ps_size == "MAX":
             columns, lines = os.get_terminal_size()
             lines -= 4
-            columns = min(columns - 17, 160)
+            columns = min(columns - 19, 160)
             return _util.session_ps_14bit(lines, columns)
 
         if session_ps_size == "MAX255":
             columns, lines = os.get_terminal_size()
             lines -= 4
-            columns = max(columns - 17, 255)
+            columns = max(columns - 19, 255)
             return _util.session_ps_14bit(lines, columns)
 
         if session_ps_size == "FULL":


### PR DESCRIPTION
Ths PR should have gone with #141. With #141, the session selector requires an additional character of width. But, when deciding on a maximum ps_size, the additional width of the session selector was not considered. When using MAX or MAX255, the changes in this PR will choose a ps_size so that the session selector will fit on the screen.