### PR TITLE
ubuntu 22.04 for python 3.7

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -27,11 +27,15 @@ jobs:
 
   test-wheel:
     needs: build-wheel
-    runs-on: ubuntu-latest
     strategy:
       matrix:
         python-version: [ '3.7', '3.8', '3.9', '3.10', '3.11', '3.12' ]
+        include:
+          - os: ubuntu-latest
+          - python-version: '3.7'
+            os: ubuntu-22.04
 
+    runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}


### PR DESCRIPTION
This PR addresses a current issue with the CI/CD pipeline that is apparently introduced by `ubuntu-latest` getting bumped from `22.04.5` to `24.04`, which does not seem to have Python 3.7. Rather than remove the testing under Python 3.7, the Python 3.7 testing is changed to stay at `22.04`.