### PR TITLE
workaround checkout fetch-tags issue

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -56,13 +56,11 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-      with:
-        fetch-tags: true
-
     - uses: actions/setup-python@v5
       with:
         python-version: 3.12
 
+    - run: git fetch --tags
     - run: pip install --disable-pip-version-check -r requirements.txt
     - uses: actions/download-artifact@v4
     - run: twine upload --non-interactive -u __token__ dist/*


### PR DESCRIPTION
This PR is a work around for actions/checkout#1467. It addresses the following error:
```
Cannot fetch both 1194e3f1f631b9aeb3c09e1c292968369af72eef and refs/tags/v0.5.0 to refs/tags/v0.5.0
```