### PR TITLE
raise tcsetattr error

### DIFF
--- a/tnz/_termlib.py
+++ b/tnz/_termlib.py
@@ -1651,13 +1651,13 @@ class Term():
         if when is None:
             when = termios.TCSANOW
 
-        while True:
-            try:
-                termios.tcsetattr(termi_fd, when, attr)
-                return
+        try:
+            termios.tcsetattr(termi_fd, when, attr)
 
-            except termios.error:
-                _logger.exception("tcsetattr")
+        except termios.error:
+            raise _TermlibError("tcsetattr error")
+
+        return
 
     @classmethod
     def __stop_thread(cls):

--- a/tnz/_termlib.py
+++ b/tnz/_termlib.py
@@ -13,7 +13,7 @@ REFERENCES:
     https://docs.microsoft.com/windows/console/
         console-virtual-terminal-sequences
 
-Copyright 2021 IBM Inc. All Rights Reserved.
+Copyright 2021, 2024 IBM Inc. All Rights Reserved.
 
 SPDX-License-Identifier: Apache-2.0
 """

--- a/tnz/ati.py
+++ b/tnz/ati.py
@@ -2197,8 +2197,8 @@ class Ati():
         return "\n".join(lines)
 
     def __close(self):
-        for tns in self.__session_tnz.values():
-            tns.shutdown()
+        while self.__session_tnz:
+            self.__drop_session()
 
     def __drop_session(self):
         """perform the DROP SESSION function

--- a/tnz/ati.py
+++ b/tnz/ati.py
@@ -88,7 +88,7 @@ Environment variables used:
     ZTI_TITLE (see zti.py)
     _BPX_TERMPATH (see _termlib.py)
 
-Copyright 2021, 2023 IBM Inc. All Rights Reserved.
+Copyright 2021, 2024 IBM Inc. All Rights Reserved.
 
 SPDX-License-Identifier: Apache-2.0
 """

--- a/tnz/ati.py
+++ b/tnz/ati.py
@@ -93,6 +93,7 @@ Copyright 2021, 2023 IBM Inc. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 """
 import asyncio
+import atexit
 import functools
 import inspect
 import logging
@@ -2195,6 +2196,10 @@ class Ati():
 
         return "\n".join(lines)
 
+    def __close(self):
+        for tns in self.__session_tnz.values():
+            tns.shutdown()
+
     def __drop_session(self):
         """perform the DROP SESSION function
 
@@ -2598,6 +2603,7 @@ class Ati():
         loop = self.__loop
         if not loop:
             loop = asyncio.new_event_loop()
+            atexit.register(self.__close)  # help with loop shutdown
 
         loop.call_soon(connect)
         loop.stop()


### PR DESCRIPTION
This PR fixes a problem where `tcsetattr()` would get a "bad file descriptor" and loop forever. The lack of looping seemed to make it more likely that the asyncio event loop tried to send data on a socket after it was closed. This PR addresses that by shutting down tnz sessions associated with an ati-managed event loop before exiting the interpreter.