### PR TITLE
run shutdown from event loop

### DIFF
--- a/tnz/ati.py
+++ b/tnz/ati.py
@@ -2230,7 +2230,13 @@ class Ati():
         self.__gv["SESSION"] = next_session
         self.__refresh_vars()
         if tns:
-            tns.shutdown()
+            if self.__loop.is_running():
+                tns.shutdown()
+            else:
+                async def shutdown():
+                    tns.shutdown()
+
+                self.__loop.run_until_complete(shutdown())
 
         # elif connected and zti, show session? TODO
 


### PR DESCRIPTION
This PR resolves #174. It corrects a problem where the ati SESSION is dropped, but the socket is not really closed/shutdown. This was happening because the shutdown/close was not being done from in the asyncio event loop. Since the functions that may drop a session had no previous requirement to **not** be running in the event loop, the old code will still be done if the event loop is already running (and the problem should not occur in that case). In the normal case where the event loop is not running, the shutdown/close will now be done from within the event loop. Manual testing has show this to be effective, but it is not clear if the socket close is actually _guaranteed_ to done synchronously.