### PR TITLE
run tests on pull requests

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -1,6 +1,10 @@
 name: CI/CD
 
-on: push
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
 
 jobs:
   build-wheel:


### PR DESCRIPTION
This PR enables the CI/CD pipeline to run on pull requests that target the main branch. This is needed for it to run on PRs from forks. This PR also adds the limitation that it will only run on pushes to the main branch (unless the branch is a PR). This is consistent with how `codeql-analysis.yml` is set up.