### PR TITLE
wait for dropped session to terminate

### DIFF
--- a/tnz/ati.py
+++ b/tnz/ati.py
@@ -1968,7 +1968,10 @@ class Ati():
                     rrv = self.__refresh(tout, keylock=False)
             elif tout > 0:
                 sleepcnt += 1
-                time.sleep(tout)
+                if self.__loop:
+                    self.__loop.run_until_complete(asyncio.sleep(tout))
+                else:
+                    time.sleep(tout)
 
             if rrv == -2:  # if force skip
                 self.__logerror(">> User SKIP")
@@ -2242,6 +2245,11 @@ class Ati():
                     tns.shutdown()
 
                 self.__loop.run_until_complete(shutdown())
+
+            while not tns.seslost:
+                tns.wait()
+
+            tns.seslost = True  # clear any exc that may ref tns
 
         # elif connected and zti, show session? TODO
 


### PR DESCRIPTION
This PR resolve #218. The basic issue was that the Python asyncio infrastructure for sockets/transports will keep references around until the `connection_lost()` Protocol method is called. Apparently, this does not happen _synchronously_ when calling `abort()` on the transport. So, `drop("SESSION")` processing is updated to wait for `connection_lost()` to be called (i.e. `Tnz.seslost` is set).

There was also concern that the exception saved in `Tnz.seslost` could reference the object and prevent garbage collection - that is set to `True` to prevent that.

Even without `drop("SESSION")` processing waiting, future `wait()` calls would allow the `connection_lost()` Protocol to complete. However, if this is the _last session_, `time.sleep()` was being used - which did not allow the asyncio loop to run. This is corrected to use `asyncio.sleep()` if possible.