### PR TITLE
host arg over session_host

### DIFF
--- a/tnz/zti.py
+++ b/tnz/zti.py
@@ -58,6 +58,7 @@ import cmd
 import logging
 import os
 import platform
+import re
 import signal
 import sys
 import tempfile
@@ -3571,7 +3572,11 @@ def main():
             pass
 
     if args.host:
-        zti.cmdqueue.append(" ".join(("goto", args.host)))
+        hostname = args.host
+        mat = _hostportpat.fullmatch(hostname)
+        sesname = mat[1] if mat else hostname
+        sesname = sesname.split(".", maxsplit=1)[0]
+        zti.cmdqueue.append(f"goto {sesname} {hostname}")
         zti.single_session = True
 
     if args.rcfile is not None and ati.ati.session == ati.ati.sessions:
@@ -3604,5 +3609,6 @@ _WAIT_HOLDING = 7
 _WAIT_NOT_MORE = 8
 _WAIT_NOT_HOLDING = 9
 
-_osname = platform.system()
+_hostportpat = re.compile("([a-zA-Z0-9]+)(|:[0-9]+)")
 _logger = logging.getLogger("tnz.zti")
+_osname = platform.system()


### PR DESCRIPTION
This PR resolves #274. With this PR, specifying a `host` on the `zti` command line results in a `GOTO SESNAME host` command instead of a `GOTO host` command. This ensures that the `SESSION_HOST` variable is not used as a default hostname for the command/argument. Similar to (but more robust than) the way that `GOTO` will derive a `SESNAME` when not specified, the `SESNAME` specified on the `GOTO` command is derived from the specified hostname.