### PR TITLE
Python >= 3.9 required

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -34,11 +34,9 @@ jobs:
     needs: build-wheel
     strategy:
       matrix:
-        python-version: [ '3.7', '3.8', '3.9', '3.10', '3.11', '3.12', '3.13' ]
+        python-version: [ '3.9', '3.10', '3.11', '3.12', '3.13' ]
         include:
           - os: ubuntu-latest
-          - python-version: '3.7'
-            os: ubuntu-22.04
 
     runs-on: ${{ matrix.os }}
     steps:

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ stream. The ati module allows for easier 3270 terminal automation.
 
 ## Installing
 
-Python 3.6 or later is required.
+Python 3.9 or later is required.
 Although not required, on platforms other than z/OS, it is suggested
 you also install the [ebcdic](https://pypi.org/project/ebcdic)
 package from PyPI.

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,7 +18,7 @@ stream. The ati module allows for easier 3270 terminal automation.
 
 ## Installing
 
-Python 3.6 or later is required.
+Python 3.9 or later is required.
 Although not required, on platforms other than z/OS, it is suggested
 you also install the [ebcdic](https://pypi.org/project/ebcdic)
 package from PyPI.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "tnz"
 dynamic = ["version"]
 description = "Telnet-3270 to Z tool and library"
-requires-python = ">=3.6"
+requires-python = ">=3.9"
 
 [[project.authors]]
 name = "Neil Johnson"

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,6 @@ mkdocs-minify-plugin==0.8.0
 mkdocstrings-python==1.17.0
 pycodestyle==2.14.0
 pylint==3.3.8
-pytest==8.3.5; python_version>="3.8"
-pytest>=7.4.2; python_version<"3.8"
+pytest==8.3.5
 twine==6.1.0; sys_platform!="zos"
 wheel==0.45.1

--- a/tnz/tnz.py
+++ b/tnz/tnz.py
@@ -13,7 +13,7 @@ Environment variables used:
     TNZ_LOGGING
     ZTI_SECLEVEL
 
-Copyright 2021, 2024 IBM Inc. All Rights Reserved.
+Copyright 2021, 2025 IBM Inc. All Rights Reserved.
 
 SPDX-License-Identifier: Apache-2.0
 """
@@ -2148,11 +2148,6 @@ class Tnz:
             elif data[2] == 46:  # START_TLS
                 if os.environ.get("SESSION_SSL") == "NEVER":
                     self.__log_info("START_TLS SESSION_SSL=NEVER.")
-                    self.send_wont(data[2], buffer=True)
-
-                elif not hasattr(self.__loop, "start_tls"):
-                    self._log_warn("START_TLS unsupported.")
-                    self._log_warn("Python >= 3.7 required")
                     self.send_wont(data[2], buffer=True)
 
                 else:

--- a/tnz/zti.py
+++ b/tnz/zti.py
@@ -33,7 +33,7 @@ Environment variables used:
     ZTI_TITLE
     _BPX_TERMPATH (see _termlib.py)
 
-Copyright 2021, 2024 IBM Inc. All Rights Reserved.
+Copyright 2021, 2025 IBM Inc. All Rights Reserved.
 
 SPDX-License-Identifier: Apache-2.0
 """
@@ -859,7 +859,6 @@ class Zti(cmd.Cmd):
         # appear as a 'documented command'. Need to refine this command.
 
         self.__shell_mode(init=True)
-        # curses.update_lines_cols() not in z/OS python3.6
         maxy, maxx = self.stdscr.getmaxyx()
 
         if arg:
@@ -1791,11 +1790,7 @@ HELP and HELP KEYS commands for more information.
         _logger.debug("end __display")
 
     def __install_plugins(self):
-        try:
-            from importlib.metadata import entry_points
-        except ImportError:  # must be Python <3.8
-            self.plugins = ""
-            return
+        from importlib.metadata import entry_points
 
         plugins = []
         eps = entry_points()


### PR DESCRIPTION
This PR drops support for Python 3.8 (and lower). This will allow development to proceed without concern for unsupported levels of Python and simplified CI/CD.