### PR TITLE
get_event_loop for in Python 3.14

### DIFF
--- a/tnz/ati.py
+++ b/tnz/ati.py
@@ -679,10 +679,10 @@ class Ati():
         loop = self.__loop
         if not loop:
             try:
-              loop = asyncio.get_event_loop()
+                loop = asyncio.get_event_loop()
 
             except RuntimeError:  # >= Python 3.14 and no current loop
-              loop = asyncio.new_event_loop()
+                loop = asyncio.new_event_loop()
 
             self.__event = asyncio.Event()
             self.__loop = loop

--- a/tnz/tnz.py
+++ b/tnz/tnz.py
@@ -3829,10 +3829,10 @@ class Tnz:
         loop = self.__loop
         if not loop:
             try:
-              loop = asyncio.get_event_loop()
+                loop = asyncio.get_event_loop()
 
             except RuntimeError:  # >= Python 3.14 and no current loop
-              loop = asyncio.new_event_loop()
+                loop = asyncio.new_event_loop()
 
             self.__loop = loop
             if not self._event:


### PR DESCRIPTION
This PR resolves #298. For versions of python less than 3.14, it should have no impact.