### PR TITLE
fix typo: publisher -> publish

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -66,4 +66,4 @@ jobs:
 
     steps:
     - uses: actions/download-artifact@v4
-    - uses: pypa/gh-action-pypi-publisher@release/v1
+    - uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
This PR corrects a typo in the name of the GitHub action used to publish to pypi.