### PR TITLE
mkdocs -> zensical

### DIFF
--- a/.github/workflows/mkdocs-build.yml
+++ b/.github/workflows/mkdocs-build.yml
@@ -12,7 +12,7 @@ jobs:
   deploy-gh-pages:
     environment:
       name: github-pages
-      url: ${{ steps.deployment.outpus.page_url }}
+      url: ${{ steps.deployment.outputs.page_url }}
 
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/mkdocs-build.yml
+++ b/.github/workflows/mkdocs-build.yml
@@ -1,11 +1,19 @@
-name: mkdocs-build
+name: zensical-build
 on:
   push:
     branches:
       - main
 
+permissions:
+  pages: write
+  id-token: write
+
 jobs:
   deploy-gh-pages:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outpus.page_url }}
+
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
@@ -17,4 +25,9 @@ jobs:
         python-version: 3.13
 
     - run: pip install --disable-pip-version-check -r requirements.txt
-    - run: mkdocs gh-deploy --force
+    - run: zensical build --clean
+    - uses: actions/upload-pages-artifact@v4
+      with:
+        path: site
+
+    - uses: actions/deploy-pages@v4

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -32,7 +32,7 @@ jobs:
         path: dist/
 
     - run: python -mzipfile -l $(ls dist/*.whl)
-    - run: mkdocs build
+    - run: zensical build
 
   test-wheel:
     needs: build-wheel

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -91,4 +91,4 @@ markdown_extensions:
     - pymdownx.details:
     - pymdownx.tabbed:
 
-copyright: Copyright &copy; IBM 2022, 2025
+copyright: Copyright &copy; IBM 2022, 2026

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,4 @@
 ebcdic==2.0.1; sys_platform!="zos"
-Markdown==3.10.2
-mkdocstrings==1.0.3
 mkdocstrings-python==2.0.3
 pycodestyle==2.14.0
 pylint==3.3.9

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 ebcdic==2.0.1; sys_platform!="zos"
-griffe==1.14.0
-mkdocs-material==9.7.5
-mkdocs-minify-plugin==0.8.0
-mkdocstrings-python==1.18.2
+Markdown==3.10.2
+mkdocstrings==1.0.3
+mkdocstrings-python==2.0.3
 pycodestyle==2.14.0
 pylint==3.3.9
 pytest==8.4.2
+zensical==0.0.28


### PR DESCRIPTION
The PR changes the use of `mkdocs` to `zensical`. This is a migration path in anticipation of MkDocs 2.0, which is incompatible and not yet released. Note that zensical will use the existing `mkdocs.yml`. If zensical will be used long term, that file should eventually be migrated to a `zensical.toml`. Along with that compatible naming, the name of the GitHub action file is kept the same.