### PR TITLE
upgrade pytest

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -38,7 +38,7 @@ jobs:
     needs: build-wheel
     strategy:
       matrix:
-        python-version: [ '3.9', '3.10', '3.11', '3.12', '3.13' ]
+        python-version: [ '3.10', '3.11', '3.12', '3.13' ]
         include:
           - os: ubuntu-latest
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@ ebcdic==2.0.1; sys_platform!="zos"
 mkdocstrings-python==2.0.3
 pycodestyle==2.14.0
 pylint==3.3.9
-pytest==8.4.2
+pytest==9.0.3
 zensical==0.0.28


### PR DESCRIPTION
This PR upgrades the version of pytest used for testing tnz. The latest version of pytest requires Python >=3.10, so testing on Python 3.9 is removed with this PR. In the near future, tnz should probably drop support for Python 3.9.