### PR TITLE
>=Python 3.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ stream. The ati module allows for easier 3270 terminal automation.
 
 ## Installing
 
-Python 3.9 or later is required.
+Python 3.10 or later is required.
 Although not required, on platforms other than z/OS, it is suggested
 you also install the [ebcdic](https://pypi.org/project/ebcdic)
 package from PyPI.

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,7 +18,7 @@ stream. The ati module allows for easier 3270 terminal automation.
 
 ## Installing
 
-Python 3.9 or later is required.
+Python 3.10 or later is required.
 Although not required, on platforms other than z/OS, it is suggested
 you also install the [ebcdic](https://pypi.org/project/ebcdic)
 package from PyPI.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "tnz"
 dynamic = ["version"]
 description = "Telnet-3270 to Z tool and library"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 
 [[project.authors]]
 name = "Neil Johnson"


### PR DESCRIPTION
This PR raises the minimum Python version to 3.10. Moving up Python versions is critical to keep current with packages and avoid security vulnerabilities.