### PR TITLE
rename tns.name for diagnostics

### DIFF
--- a/tnz/ati.py
+++ b/tnz/ati.py
@@ -796,6 +796,7 @@ class Ati():
         self.__session_tnz[unam] = tns
         self.__gv["SESSION"] = unam
         del self.__session_tnz[session]
+        tns.name = unam
 
         self.__logresult("SESSION = %r", unam)
 


### PR DESCRIPTION
This PR improves diagnostics by updating the ati.rename function to keep the tnz object name in sync.